### PR TITLE
Support for HTML/markdown tables in description parser

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,13 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog],
 and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
 
+== 0.5.5 (8 Jun 2020)
+
+=== Fixed
+
+  - Support for HTML/markdown tables in description parser.
+
+
 == 0.5.4 (21 May 2020)
 
 === Changed

--- a/tests/test_doxygenparser__description_parser.py
+++ b/tests/test_doxygenparser__description_parser.py
@@ -290,6 +290,33 @@ def test_table(nested_elements, nested_result):
 
 |===""")
 
+def test_table_with_nested_itemizedlist():
+    description = ET.Element("description")
+    para = sub_element(description, "para")
+    table = sub_element(para, "table", rows="1", cols="1")
+    row = sub_element(table, "row")
+    entry = sub_element(row, "entry", thead="no")
+    para = sub_element(entry, "para", text="This is a list of items:")
+    itemized_list = sub_element(para, "itemizedlist")
+
+    list_item_1 = sub_element(itemized_list, "listitem")
+    para_1 = sub_element(list_item_1, "para", text="List item 1")
+
+    list_item_2 = sub_element(itemized_list, "listitem")
+    sub_element(list_item_2, "para", text="List item 2")
+
+    result = DescriptionParser("lang").parse(description)
+    assert result == """[cols=1*]
+|===
+
+|This is a list of items:
+
+* List item 1
+
+* List item 2
+
+|==="""
+
 def test_table_with_header():
     description = ET.Element("description")
     para = sub_element(description, "para")

--- a/tests/test_doxygenparser__description_parser.py
+++ b/tests/test_doxygenparser__description_parser.py
@@ -263,6 +263,7 @@ def test_remove_single_leading_space():
 
 And some more text."""
 
+
 @pytest.mark.parametrize("nested_elements, nested_result", nested_formatting())
 def test_table(nested_elements, nested_result):
     description = ET.Element("description")
@@ -289,6 +290,7 @@ def test_table(nested_elements, nested_result):
 |col=1,row=1{nested_result}
 
 |===""")
+
 
 def test_table_with_nested_itemizedlist():
     description = ET.Element("description")
@@ -317,6 +319,7 @@ def test_table_with_nested_itemizedlist():
 
 |==="""
 
+
 def test_table_with_header():
     description = ET.Element("description")
     para = sub_element(description, "para")
@@ -337,6 +340,7 @@ def test_table_with_header():
 |content
 
 |==="""
+
 
 def test_table_with_caption():
     description = ET.Element("description")


### PR DESCRIPTION
Closes #11 

Known issues:

- Column alignment [described in Doxygen documentation](https://www.doxygen.nl/manual/markdown.html#md_tables) seems not to work. XML output of Doxygen doesn't keep any information about it.
- Cols and rows spanning doesn't work. XML output just generates appropriate number of entires for each row, giving no hint of whether a cell should be spanned across multiple rows or cols.
- Missing support for [inner tables](https://www.doxygen.nl/manual/tables.html).