### PR TITLE
List constants properly in Java templates

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,13 +1,13 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Test python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/asciidoxy/templates/java/class.mako
+++ b/asciidoxy/templates/java/class.mako
@@ -47,22 +47,22 @@ ${enclosed.brief}
 
 % endif
 ###################################################################################################
+% if has(helper.public_constants()):
+|*Constants*
+|
+% for constant in helper.public_constants():
+`xref:${constant.id}[${constant.returns.type.name} ${constant.name}]`::
+${constant.brief}
+% endfor
+
+% endif
+###################################################################################################
 % if has(helper.public_constructors()):
 |*Constructors*
 |
 % for constructor in helper.public_constructors():
 `xref:${constructor.id}[${constructor.name}${helper.type_list(constructor.params)}]`::
 ${constructor.brief}
-% endfor
-
-% endif
-###################################################################################################
-% if has(helper.public_constants()):
-|*Constants*
-|
-% for constant in helper.public_constants():
-`${constant.name}`::
-${constant.description}
 % endfor
 
 % endif
@@ -89,6 +89,21 @@ ${method.brief}
 |===
 
 == Members
+###################################################################################### Constants ##
+% for constant in helper.public_constants():
+[[${constant.id},${constant.name}]]
+${api_context.insert(constant)}
+[source,java,subs="-specialchars,macros+"]
+----
+${constant.returns.type.name} ${constant.name}
+----
+
+${constant.brief}
+
+${constant.description}
+
+'''
+% endfor
 ################################################################################### Constructors ##
 % for constructor in helper.public_constructors():
 [[${constructor.id},${constructor.name}]]

--- a/asciidoxy/templates/java/interface.mako
+++ b/asciidoxy/templates/java/interface.mako
@@ -41,8 +41,8 @@ ${element.description}
 |*Constants*
 |
 % for constant in helper.public_constants():
-`${constant.name}`::
-${constant.description}
+`xref:${constant.id}[${constant.returns.type.name} ${constant.name}]`::
+${constant.brief}
 % endfor
 
 % endif
@@ -69,6 +69,21 @@ ${method.brief}
 |===
 
 == Members
+###################################################################################### Constants ##
+% for constant in helper.public_constants():
+[[${constant.id},${constant.name}]]
+${api_context.insert(constant)}
+[source,java,subs="-specialchars,macros+"]
+----
+${constant.returns.type.name} ${constant.name}
+----
+
+${constant.brief}
+
+${constant.description}
+
+'''
+% endfor
 ################################################################################# Static methods ##
 % for method in helper.public_static_methods():
 [[${method.id},${method.name}]]


### PR DESCRIPTION
- Constants are now listed both in table overview of the class (added type and brief description) and in the detailed Members section below (this was missing previously) along with long description.
- They are now noted before Constructors, as is common in actual code.