### PR TITLE
Fix name for the packages spec file to new TOML format extension

### DIFF
--- a/documentation/getting-started/api-reference.adoc
+++ b/documentation/getting-started/api-reference.adoc
@@ -109,7 +109,7 @@ Doxygen XML output, and make it available for use in AsciiDoc files:
 
 [source]
 ----
-asciidoxy --spec-file packages.spec INPUT_FILE
+asciidoxy --spec-file packages.toml INPUT_FILE
 ----
 
 == Including API reference in AsciiDoc files

--- a/documentation/getting-started/packages.adoc
+++ b/documentation/getting-started/packages.adoc
@@ -106,7 +106,7 @@ The package specification file is provided to AsciiDoxy using the command-line o
 
 [source]
 ----
-asciidoxy --spec-file packages.spec INPUT_FILE
+asciidoxy --spec-file packages.toml INPUT_FILE
 ----
 
 [TIP]


### PR DESCRIPTION
The documentation still uses `packages.spec` as the filename but the examples have you create a `packages.toml` file.