### PR TITLE
Add nonav option to skip navigation bar in multipage HTML

### DIFF
--- a/asciidoxy/asciidoctor.py
+++ b/asciidoxy/asciidoctor.py
@@ -50,6 +50,9 @@ def generate_attributes(doc: Document, config: Configuration, pkg_mgr: PackageMa
     if config.multipage:
         values.append("multipage")
 
+    if config.nonav:
+        values.append("nonav")
+
     values.extend(config.attribute)
     return " ".join(values)
 

--- a/asciidoxy/config.py
+++ b/asciidoxy/config.py
@@ -75,6 +75,7 @@ class Configuration(argparse.Namespace):
     log_level: str
     force_language: Optional[str] = None
     multipage: bool
+    nonav: bool
 
     safe_mode: str
     attribute: List[str]
@@ -146,6 +147,10 @@ def parse_args(argv):
     behavior_group.add_argument("--multipage",
                                 action="store_true",
                                 help="Generate multi-page document.")
+    behavior_group.add_argument("--nonav",
+                                action="store_true",
+                                help="When used with --multipage."
+                                " Generate multi-page document (without navigation bar).")
     behavior_group.add_argument("-W",
                                 "--warnings-are-errors",
                                 action="store_true",

--- a/asciidoxy/generator/asciidoc.py
+++ b/asciidoxy/generator/asciidoc.py
@@ -894,10 +894,11 @@ class GeneratingApi(Api):
 
         with self._context.document.work_file.open("w", encoding="utf-8") as f:
             print(rendered_doc, file=f)
-            if self._context.config.multipage and not self._context.document.is_embedded:
-                nav_bar = navigation_bar(self._context.document)
-                if nav_bar:
-                    print(nav_bar, file=f)
+            if not self._context.config.nonav:
+                if self._context.config.multipage and not self._context.document.is_embedded:
+                    nav_bar = navigation_bar(self._context.document)
+                    if nav_bar:
+                        print(nav_bar, file=f)
 
         self._copy_stylesheet()
 


### PR DESCRIPTION
I need to generate standalone HTML files for my use case. The multipage option will generate separate files from but includes the navigation bar to tie into the larger document. Add an option to omit this navigation bar.