### PR TITLE
Add allow_overloads to insert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	#python3 setup.py install
-	pip install
+	pip install .
 
 virtualenv: ## set up a development environment
 	python3 -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ dist: clean ## builds source and wheel package
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python3 setup.py install
+	#python3 setup.py install
+	pip install
 
 virtualenv: ## set up a development environment
 	python3 -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ install: clean ## install the package to the active Python's site-packages
 	#python3 setup.py install
 	pip install .
 
+container-install: clean ## install the package to the active Python's site-packages
+	#python3 setup.py install
+	pip install --break-system-packages .
+
 virtualenv: ## set up a development environment
 	python3 -m venv .venv
 	. .venv/bin/activate && pip install wheel

--- a/asciidoxy/api_reference.py
+++ b/asciidoxy/api_reference.py
@@ -372,6 +372,10 @@ class ApiReference:
         # TODO assert element.id not in self._id_index
         self._id_index[element.id] = element
 
+        # Handle unset name
+        if not element.name:
+            element.name = f'unknown-{element.id}'
+
         assert element.name
         self._name_index[uniform_short_name(element.name)].append(element)
 

--- a/asciidoxy/api_reference.py
+++ b/asciidoxy/api_reference.py
@@ -372,7 +372,7 @@ class ApiReference:
         # TODO assert element.id not in self._id_index
         self._id_index[element.id] = element
 
-        # Handle unset name
+        # TODO: Handle unset name
         if not element.name:
             element.name = f'unknown-{element.id}'
 

--- a/asciidoxy/generator/asciidoc.py
+++ b/asciidoxy/generator/asciidoc.py
@@ -244,6 +244,7 @@ class Api(ABC):
                members: Optional[FilterSpec] = None,
                exceptions: Optional[FilterSpec] = None,
                ignore_global_filter: bool = False,
+               allow_overloads: bool = False,
                leveloffset: str = "+1",
                template: Optional[str] = None) -> str:
         """Insert API reference documentation.
@@ -263,6 +264,7 @@ class Api(ABC):
                                       filtering on the `name` of the exception type only.
             ignore_global_filter: True to ignore the global filter set with `Api.filter()`. False
                                       to apply the filters on top of the global filter.
+            allow_overloads:      Insert first match in an overload set. Disabled by default.
             leveloffset:          Offset of the top header of the inserted text from the top level
                                       header of the including document.
             template:             *Experimental* Alternative template to use when inserting the
@@ -281,7 +283,7 @@ class Api(ABC):
         return self.insert_fragment(self.find_element(name,
                                                       kind=kind,
                                                       lang=lang,
-                                                      allow_overloads=False),
+                                                      allow_overloads=allow_overloads),
                                     insert_filter,
                                     leveloffset,
                                     kind_override=template)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,3 +24,4 @@ types-toml==0.10.8.5
 watchdog==2.3.1
 wheel==0.38.4
 yapf==0.32.0
+mako


### PR DESCRIPTION
This PR just passes the `allow_overloads` attribute of #find_element through to avoid my issue #124. 

Additionally it adds a quick check for empty `element.name` to bypass the following assert, which fails for me most of the time even in trivial projects.